### PR TITLE
get_ordered_langs function change

### DIFF
--- a/inc/query-filtering/wpml-slug-resolution.class.php
+++ b/inc/query-filtering/wpml-slug-resolution.class.php
@@ -20,9 +20,11 @@ abstract class WPML_Slug_Resolution extends WPML_WPDB_And_SP_User {
 	 */
 	protected function get_ordered_langs() {
 		$lang_order   = $this->sitepress->get_setting( 'languages_order' );
+		if (is_string($lang_order) || !$lang_order) {
+		    $lang_order = array_keys($this->sitepress->get_active_languages());
+		}
 		$lang_order   = $lang_order ? $lang_order : array_keys( $this->sitepress->get_active_languages() );
 		array_unshift( $lang_order, $this->sitepress->get_current_language() );
-
 		return array_unique( $lang_order );
 	}
 


### PR DESCRIPTION
In some version, attribute languages_order is a string.  I use the latest version of the plugin. I checked this in wp_options table, and lanuages_order in icl_sitepress_settings is a string.